### PR TITLE
CMakeLists: add missing default directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,5 +49,6 @@ set(CPACK_PROJECT_NAME ${PROJECT_NAME})
 set(CPACK_PROJECT_VERSION ${PROJECT_VERSION})
 include(CPack)
 
+install(DIRECTORY DESTINATION  /usr/share/KrillKounter)
 install(TARGETS KrillKounter RUNTIME DESTINATION /usr/bin)
 install(FILES src/daemon/service/KrillKounter.service DESTINATION /lib/systemd/system)


### PR DESCRIPTION
The stats.json default directory is /usr/share/KrillKounter, we create the directory in CMake if it is missing

Closes #33 