### PR TITLE
CMakeLists: remove unused sigc++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,6 @@ find_package(PkgConfig REQUIRED)
 find_package(Threads REQUIRED)
 
 pkg_check_modules(JSONGLIB REQUIRED json-glib-1.0)
-pkg_check_modules(SIGNALCPP REQUIRED sigc++-3.0)
 
 # Testing
 include(CTest)
@@ -28,7 +27,6 @@ add_executable(KrillKounter src/main.cc ${sources})
 
 # Include directories
 include_directories(${JSONGLIB_INCLUDE_DIRS})
-include_directories(${SIGNALCPP_INCLUDE_DIRS})
 
 target_include_directories(KrillKounter PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/src
@@ -36,8 +34,6 @@ target_include_directories(KrillKounter PUBLIC
 
 # Link libraries
 target_link_libraries(KrillKounter PUBLIC ${JSONGLIB_LIBRARIES})
-
-target_link_libraries(KrillKounter PUBLIC ${SIGNALCPP_LIBRARIES})
 
 target_link_libraries(KrillKounter PUBLIC ${CMAKE_DL_LIBS})
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ A utility for monitoring and logging block device stats to a JSON file at a regu
 - make-4.3
 - cmake-3.22.1
 - libjson-glib-dev-1.6.6
-- libsigc++-3.0-dev
 - lsblk-2.37.2
 
 # Compilation


### PR DESCRIPTION
libsigc++ is not used and can be removed, this fixes the issue where it would not compile on ubuntu 22.04 as the package is not available

Closes #29