### PR TITLE
main: Change stat types to gint64

### DIFF
--- a/DaemonReadme.md
+++ b/DaemonReadme.md
@@ -23,7 +23,7 @@ Returns: *bool*
 
 *std::string serialNumber*
 
-*double\* pValue*
+*int\* pValue*
 
 Retreive the `totalBytesWritten` value in the entry with the key *serialNumber* from the JSON file previously opened with `openJson`. The value of `totalBytesWritten` is written to *pValue*. Returns `true` on success, `false` on failure.
 

--- a/src/daemon/cJsonParser.cc
+++ b/src/daemon/cJsonParser.cc
@@ -43,7 +43,7 @@ bool cJsonParser::closeJson()
     return true; // success
 }
 
-bool cJsonParser::getTotalBytesWritten(std::string serialNumber, double* pValue)
+bool cJsonParser::getTotalBytesWritten(std::string serialNumber, gint64 *pValue)
 {
     GError* pError      = nullptr;
     JsonReader* pReader = json_reader_new(json_parser_get_root(_pJsonParser));
@@ -57,7 +57,7 @@ bool cJsonParser::getTotalBytesWritten(std::string serialNumber, double* pValue)
 
     json_reader_read_member(pReader, serialNumber.c_str());
     json_reader_read_member(pReader, "totalBytesWritten");
-    double output = (double)json_reader_get_double_value(pReader);
+    auto output = json_reader_get_int_value(pReader);
 
     pError = (GError*)json_reader_get_error(pReader);
     if (pError)
@@ -210,7 +210,7 @@ bool cJsonParser::getSerialNumbers(std::vector<std::string>* pValue)
 // private function
 
 bool cJsonParser::getValueAsInt(
-    JsonReader* pReader, std::string itemName, int* pValue)
+    JsonReader* pReader, std::string itemName, gint64* pValue)
 {
     json_reader_read_member(pReader, itemName.c_str());
     int value = (int)json_reader_get_int_value(pReader);

--- a/src/daemon/cJsonParser.hh
+++ b/src/daemon/cJsonParser.hh
@@ -12,14 +12,14 @@ class cJsonParser
     public:
         bool openJson(std::string jsonPath);
         bool closeJson();
-        bool getTotalBytesWritten(std::string serialNumber, double* pValue);
+        bool getTotalBytesWritten(std::string serialNumber, gint64* pValue);
         bool getStats(std::string serialNumber, struct sBlockStats* pStats);
         bool getPath(std::string serialNumber, std::string* pValue);
         bool getSerialNumbers(std::vector<std::string>* pValue);
 
     private:
         bool getValueAsInt(
-            JsonReader* pReader, std::string itemName, int* pValue);
+            JsonReader* pReader, std::string itemName, gint64 * pValue);
         JsonParser* _pJsonParser;
         int _parserOpen = false;
 };

--- a/src/daemon/cJsonWriter.cc
+++ b/src/daemon/cJsonWriter.cc
@@ -191,7 +191,7 @@ void cJsonWriter::addEntryToBuilder(std::string serialNumber,
     // - totalBytesWritten
     json_builder_end_object(_pJsonBuilder);
     json_builder_set_member_name(_pJsonBuilder, "totalBytesWritten");
-    json_builder_add_double_value(_pJsonBuilder, totalBytesWritten);
+    json_builder_add_int_value(_pJsonBuilder, totalBytesWritten);
     // close
     json_builder_end_object(_pJsonBuilder);
 }

--- a/src/library/cStatComputer.cc
+++ b/src/library/cStatComputer.cc
@@ -7,11 +7,11 @@ uint cStatComputer::getAverageWriteSize(
     return (sectorSize * pDeviceStats->writeSectors) / pDeviceStats->writeIo;
 }
 
-float cStatComputer::totalBytesWritten(uint sectorSize,
-    uintmax_t currentWriteSectors, uintmax_t previousWriteSectors,
-    float previousTotal)
+gint64 cStatComputer::totalBytesWritten(uint sectorSize,
+    gint64 currentWriteSectors, gint64 previousWriteSectors,
+    gint64 previousTotal)
 {
-    uintmax_t newTotal = previousTotal;
+    gint64 newTotal = previousTotal;
     if (currentWriteSectors < previousWriteSectors)
     {
         /* overflow occured, calculate difference:

--- a/src/library/cStatComputer.hh
+++ b/src/library/cStatComputer.hh
@@ -12,8 +12,8 @@ class cStatComputer
     public:
         uint getAverageWriteSize(
             struct sBlockStats* pDeviceStats, uint sectorSize);
-        float totalBytesWritten(uint sectorSize, uintmax_t currentWriteSectors,
-            uintmax_t previousWriteSectors, float previousTotal);
+        gint64 totalBytesWritten(uint sectorSize, gint64 currentWriteSectors,
+            gint64 previousWriteSectors, gint64 previousTotal);
 };
 
 #endif /* _CSTATCOMPUTER_H */

--- a/src/library/cStatReader.cc
+++ b/src/library/cStatReader.cc
@@ -79,21 +79,24 @@ bool cStatReader::getStats(std::string deviceName, struct sBlockStats* pStats)
         // loop for each string and add to the vector
         vec.push_back(s);
 
-    pStats->readIo         = std::stoi(vec[0]);
-    pStats->readMerges     = std::stoi(vec[1]);
-    pStats->readSectors    = std::stoi(vec[2]);
-    pStats->readTicks      = std::stoi(vec[3]);
-    pStats->writeIo        = std::stoi(vec[4]);
-    pStats->writeMerges    = std::stoi(vec[5]);
-    pStats->writeSectors   = std::stoi(vec[6]);
-    pStats->writeTicks     = std::stoi(vec[7]);
-    pStats->inFlight       = std::stoi(vec[8]);
-    pStats->ioTicks        = std::stoi(vec[9]);
-    pStats->timeInQueue    = std::stoi(vec[10]);
-    pStats->discardIo      = std::stoi(vec[11]);
-    pStats->discardMerges  = std::stoi(vec[12]);
-    pStats->discardSectors = std::stoi(vec[13]);
-    pStats->discardTicks   = std::stoi(vec[14]);
+    pStats->readIo         = (gint64) std::stoul(vec[0]);
+    pStats->readMerges     = (gint64) std::stoul(vec[1]);
+    pStats->readSectors    = (gint64) std::stoul(vec[2]);
+    pStats->readTicks      = (gint64) std::stoi(vec[3]);
+
+    pStats->writeIo        = (gint64) std::stoul(vec[4]);
+    pStats->writeMerges    = (gint64) std::stoul(vec[5]);
+    pStats->writeSectors   = (gint64) std::stoul(vec[6]);
+    pStats->writeTicks     = (gint64) std::stoi(vec[7]);
+
+    pStats->inFlight       = (gint64) std::stoi(vec[8]);
+    pStats->ioTicks        = (gint64) std::stoi(vec[9]);
+    pStats->timeInQueue    = (gint64) std::stoi(vec[10]);
+
+    pStats->discardIo      = (gint64) std::stoul(vec[11]);
+    pStats->discardMerges  = (gint64) std::stoul(vec[12]);
+    pStats->discardSectors = (gint64) std::stoul(vec[13]);
+    pStats->discardTicks   = (gint64) std::stoi(vec[14]);
 
     return true; // success
 }

--- a/src/library/include/structs.hh
+++ b/src/library/include/structs.hh
@@ -2,6 +2,7 @@
 #ifndef _STRUCTS_H
 #define _STRUCTS_H
 
+#include <glib.h>
 #include <string>
 
 struct sBlockStatStub
@@ -12,21 +13,21 @@ struct sBlockStatStub
 
 struct sBlockStats
 {
-        int readIo;
-        int readMerges;
-        int readSectors;
-        int readTicks;
-        int writeIo;
-        int writeMerges;
-        int writeSectors;
-        int writeTicks;
-        int inFlight;
-        int ioTicks;
-        int timeInQueue;
-        int discardIo;
-        int discardMerges;
-        int discardSectors;
-        int discardTicks;
+        gint64 readIo;
+        gint64 readMerges;
+        gint64 readSectors;
+        gint64 readTicks;
+        gint64 writeIo;
+        gint64 writeMerges;
+        gint64 writeSectors;
+        gint64 writeTicks;
+        gint64 inFlight;
+        gint64 ioTicks;
+        gint64 timeInQueue;
+        gint64 discardIo;
+        gint64 discardMerges;
+        gint64 discardSectors;
+        gint64 discardTicks;
 };
 
 struct sDeviceSpecs
@@ -45,7 +46,7 @@ struct jsonDeviceEntry
         std::string serialNumber;
         std::string previousPath;
         struct sBlockStats stats;
-        double totalBytesWritten;
+        gint64 totalBytesWritten;
 };
 
 #endif /* _STRUCTS_H */


### PR DESCRIPTION
The JSON library will read and write the values as `gint64`, this means that on a 32 bit system, we are incorrectly storing the stat values.

e.g. writeSectors is an unsigned long, by reading with `strtoul` and then casting to `gint64` we avoid it becoming negative in a cast from unsigned to signed, or dropping bits (if we were instead to use the `int` type)

totalBytesWritten does not need to be a `double` and was also changed to a `gint64`

Closes #54