### PR TITLE
main: Fix stats updating

### DIFF
--- a/src/daemon/cJsonParser.cc
+++ b/src/daemon/cJsonParser.cc
@@ -74,6 +74,54 @@ bool cJsonParser::getTotalBytesWritten(std::string serialNumber, gint64 *pValue)
     return true; // success
 }
 
+bool cJsonParser::getDiskSeq(std::string serialNumber, gint64 *pValue)
+{
+    GError* pError      = nullptr;
+    JsonReader* pReader = json_reader_new(json_parser_get_root(_pJsonParser));
+    pError              = (GError*)json_reader_get_error(pReader);
+    if (pError)
+    {
+        LOG_EVENT(LOG_ERR, "Unable to parse file: %s\n", pError->message);
+        g_error_free(pError);
+        return false; // failure
+    }
+
+    json_reader_read_member(pReader, serialNumber.c_str());
+    pError = (GError*)json_reader_get_error(pReader);
+    if (pError)
+    {
+        LOG_EVENT(LOG_ERR, "Error parsing 'serialNumber': %s\n",
+            pError->message);
+        json_reader_end_member(pReader);
+        return false; // failure
+    }
+
+    json_reader_read_member(pReader, "diskSeq");
+    pError = (GError*)json_reader_get_error(pReader);
+    if (pError)
+    {
+        LOG_EVENT(LOG_ERR, "Error parsing 'diskSeq': %s\n",
+            pError->message);
+        json_reader_end_member(pReader);
+        return false; // failure
+    }
+
+    auto output = json_reader_get_int_value(pReader);
+    pError = (GError*)json_reader_get_error(pReader);
+    if (pError)
+    {
+        LOG_EVENT(LOG_ERR, "Error parsing 'diskSeq': %s\n",
+            pError->message);
+        json_reader_end_member(pReader);
+        return false; // failure
+    }
+
+    *pValue = output;
+
+    g_object_unref(pReader);
+    return true; // success
+}
+
 bool cJsonParser::getStats(std::string serialNumber, struct sBlockStats* pStats)
 {
     GError* pError      = nullptr;

--- a/src/daemon/cJsonParser.hh
+++ b/src/daemon/cJsonParser.hh
@@ -13,6 +13,7 @@ class cJsonParser
         bool openJson(std::string jsonPath);
         bool closeJson();
         bool getTotalBytesWritten(std::string serialNumber, gint64* pValue);
+        bool getDiskSeq(std::string serialNumber, gint64* pValue);
         bool getStats(std::string serialNumber, struct sBlockStats* pStats);
         bool getPath(std::string serialNumber, std::string* pValue);
         bool getSerialNumbers(std::vector<std::string>* pValue);

--- a/src/daemon/cJsonWriter.cc
+++ b/src/daemon/cJsonWriter.cc
@@ -13,7 +13,7 @@ cJsonWriter::cJsonWriter() { _pJsonBuilder = json_builder_new(); }
 bool cJsonWriter::writeJson(std::string jsonPathInput,
     std::string jsonPathOutput, std::string serialNumber,
     std::string previousPath, struct sBlockStats* pStats,
-    uintmax_t totalBytesWritten)
+    gint64 diskSeq, gint64 totalBytesWritten)
 {
     json_builder_begin_object(_pJsonBuilder);
 
@@ -34,7 +34,7 @@ bool cJsonWriter::writeJson(std::string jsonPathInput,
         for (uint i = 0; i < devices.size(); i++)
         {
             addEntryToBuilder(devices[i].serialNumber, devices[i].previousPath,
-                &(devices[i].stats), devices[i].totalBytesWritten);
+                &(devices[i].stats), devices[i].diskSeq, devices[i].totalBytesWritten);
         }
 
         f.close();
@@ -47,7 +47,7 @@ bool cJsonWriter::writeJson(std::string jsonPathInput,
     via addEntryToBuilder() above, then the values for that entry will be
     overwritten here before any json is generated or written back to disk.
     */
-    addEntryToBuilder(serialNumber, previousPath, pStats, totalBytesWritten);
+    addEntryToBuilder(serialNumber, previousPath, pStats, diskSeq, totalBytesWritten);
 
     json_builder_end_object(_pJsonBuilder);
 
@@ -132,7 +132,7 @@ bool cJsonWriter::readExistingJson(
 
 void cJsonWriter::addEntryToBuilder(std::string serialNumber,
     std::string previousPath, struct sBlockStats* pStats,
-    uintmax_t totalBytesWritten)
+    gint64 diskSeq, gint64 totalBytesWritten)
 {
     // serial number
     json_builder_set_member_name(_pJsonBuilder, serialNumber.c_str());
@@ -190,6 +190,8 @@ void cJsonWriter::addEntryToBuilder(std::string serialNumber,
     json_builder_add_int_value(_pJsonBuilder, pStats->discardTicks);
     // - totalBytesWritten
     json_builder_end_object(_pJsonBuilder);
+    json_builder_set_member_name(_pJsonBuilder, "diskSeq");
+    json_builder_add_int_value(_pJsonBuilder, diskSeq);
     json_builder_set_member_name(_pJsonBuilder, "totalBytesWritten");
     json_builder_add_int_value(_pJsonBuilder, totalBytesWritten);
     // close

--- a/src/daemon/cJsonWriter.hh
+++ b/src/daemon/cJsonWriter.hh
@@ -14,7 +14,7 @@ class cJsonWriter
         cJsonWriter();
         bool writeJson(std::string jsonPathInput, std::string jsonPathOutput,
             std::string serialNumber, std::string previousPath,
-            struct sBlockStats* pStats, uintmax_t totalBytesWritten);
+            struct sBlockStats* pStats, gint64 diskSeq, gint64 totalBytesWritten);
 
     private:
         uint _indentLevel = 4;
@@ -23,7 +23,7 @@ class cJsonWriter
             std::vector<struct jsonDeviceEntry>* pDevices);
         void addEntryToBuilder(std::string serialNumber,
             std::string previousPath, struct sBlockStats* pStats,
-            uintmax_t totalBytesWritten);
+            gint64 diskSeq, gint64 totalBytesWritten);
 };
 
 #endif /* _CJSONWRITER_H */

--- a/src/library/cStatComputer.cc
+++ b/src/library/cStatComputer.cc
@@ -32,3 +32,22 @@ gint64 cStatComputer::totalBytesWritten(uint sectorSize,
 
     return newTotal;
 }
+void cStatComputer::updateStats(struct sBlockStats* pPreviousStats,
+    struct sBlockStats* pCurrentStats, struct sBlockStats *pOutputStats)
+{
+    pOutputStats->readIo += pCurrentStats->readIo - pPreviousStats->readIo;
+    pOutputStats->readMerges += pCurrentStats->readMerges - pPreviousStats->readMerges;
+    pOutputStats->readSectors += pCurrentStats->readSectors - pPreviousStats->readSectors;
+    pOutputStats->readTicks += pCurrentStats->readTicks - pPreviousStats->readTicks;
+    pOutputStats->writeIo += pCurrentStats->writeIo - pPreviousStats->writeIo;
+    pOutputStats->writeMerges += pCurrentStats->writeMerges - pPreviousStats->writeMerges;
+    pOutputStats->writeSectors += pCurrentStats->writeSectors - pPreviousStats->writeSectors;
+    pOutputStats->writeTicks += pCurrentStats->writeTicks - pPreviousStats->writeTicks;
+    pOutputStats->inFlight += pCurrentStats->inFlight - pPreviousStats->inFlight;
+    pOutputStats->ioTicks += pCurrentStats->ioTicks - pPreviousStats->ioTicks;
+    pOutputStats->timeInQueue += pCurrentStats->timeInQueue - pPreviousStats->timeInQueue;
+    pOutputStats->discardIo += pCurrentStats->discardIo - pPreviousStats->discardIo;
+    pOutputStats->discardMerges += pCurrentStats->discardMerges - pPreviousStats->discardMerges;
+    pOutputStats->discardSectors += pCurrentStats->discardSectors - pPreviousStats->discardSectors;
+    pOutputStats->discardTicks += pCurrentStats->discardTicks - pPreviousStats->discardTicks;
+}

--- a/src/library/cStatComputer.hh
+++ b/src/library/cStatComputer.hh
@@ -14,6 +14,8 @@ class cStatComputer
             struct sBlockStats* pDeviceStats, uint sectorSize);
         gint64 totalBytesWritten(uint sectorSize, gint64 currentWriteSectors,
             gint64 previousWriteSectors, gint64 previousTotal);
+        void updateStats(struct sBlockStats *pPreviousStats,
+            struct sBlockStats *pCurrentStats, struct sBlockStats *pOutputStats);
 };
 
 #endif /* _CSTATCOMPUTER_H */

--- a/src/library/cStatReader.cc
+++ b/src/library/cStatReader.cc
@@ -52,6 +52,29 @@ bool cStatReader::getSpaceInfo(std::string deviceName, uintmax_t* pValue)
     return true; // success
 }
 
+bool cStatReader::getDiskSeq(std::string deviceName, gint64* pSeq)
+{
+    // get /sys/block/<dev>/stat
+    auto ifs = std::ifstream("/sys/block/" + deviceName + "/diskseq");
+    if (ifs.is_open() != true)
+    {
+        LOG_EVENT(LOG_ERR, "Failed to get device events");
+        return false; // failure
+    }
+    std::string line;
+    std::getline(ifs, line);
+
+    if (line.empty())
+    {
+        LOG_EVENT(LOG_ERR, "Device does not exist");
+        return false; // failure
+    }
+
+
+    *pSeq = (gint64) std::stoul(line);
+    return *pSeq > 1;
+}
+
 bool cStatReader::getStats(std::string deviceName, struct sBlockStats* pStats)
 {
     // get /sys/block/<dev>/stat

--- a/src/library/cStatReader.hh
+++ b/src/library/cStatReader.hh
@@ -13,6 +13,7 @@ class cStatReader
         std::vector<std::string> findDevices(void);
         bool getSpaceInfo(std::string deviceName, uintmax_t* pValue);
         bool getStats(std::string deviceName, struct sBlockStats* pStats);
+        bool getDiskSeq(std::string deviceName, gint64* pSeq);
         bool getSpecs(std::string deviceName, struct sDeviceSpecs* pSpecs);
 
     private:

--- a/src/library/include/structs.hh
+++ b/src/library/include/structs.hh
@@ -46,7 +46,9 @@ struct jsonDeviceEntry
         std::string serialNumber;
         std::string previousPath;
         struct sBlockStats stats;
+        struct sBlockStats outputStats;
         gint64 totalBytesWritten;
+        gint64 diskSeq;
 };
 
 #endif /* _STRUCTS_H */


### PR DESCRIPTION
The current implementation doesn't account for either the device being removed and reconnected, or the host rebooting.

We now have two stats structs in the `jsonDeviceEntry`, one to keep track of the current stats and one to store to / read from the json file. This way we can update the stats without resetting the previous data.

The disk sequence is also read in order to detect when the stats have been reset due to to the card being removed and then reconnected inbetween updates. This will only keep track of writes after the last reconnect, and any writes that occured before that (inbetween the KrillKounter update period) will not be tracked. This of course can be solved by increasing the update rate.

Closes #38