### PR TITLE
main: fix log messages

### DIFF
--- a/src/daemon/cJsonParser.cc
+++ b/src/daemon/cJsonParser.cc
@@ -219,7 +219,7 @@ bool cJsonParser::getValueAsInt(
     if (pError)
     {
         LOG_EVENT(
-            LOG_ERR, "Unable to parse '%s': %s\n", itemName, pError->message);
+            LOG_ERR, "Unable to parse '%s': %s\n", itemName.c_str(), pError->message);
         g_error_free(pError);
         return false; // failure
     }

--- a/src/daemon/cJsonWriter.cc
+++ b/src/daemon/cJsonWriter.cc
@@ -26,7 +26,7 @@ bool cJsonWriter::writeJson(std::string jsonPathInput,
         if (!readExistingJson(jsonPathInput, &devices))
         {
             LOG_EVENT(LOG_ERR, "Unable to read existing json file: %s\n",
-                jsonPathInput);
+                jsonPathInput.c_str());
             return false; // failure
         }
 
@@ -69,7 +69,7 @@ bool cJsonWriter::writeJson(std::string jsonPathInput,
     if (pError)
     {
         LOG_EVENT(LOG_ERR, "Unable to write json to file [%s]: %s\n",
-            jsonPathOutput, pError->message);
+            jsonPathOutput.c_str(), pError->message);
         g_error_free(pError);
         g_object_unref(pGen);
         json_builder_reset(_pJsonBuilder);
@@ -92,7 +92,7 @@ bool cJsonWriter::readExistingJson(
     cJsonParser parser;
     if (!parser.openJson(jsonPath))
     {
-        LOG_EVENT(LOG_ERR, "Unable to open json file: %s\n", jsonPath);
+        LOG_EVENT(LOG_ERR, "Unable to open json file: %s\n", jsonPath.c_str());
         return false; // failure
     }
 
@@ -119,7 +119,7 @@ bool cJsonWriter::readExistingJson(
         if (error)
         {
             LOG_EVENT(LOG_ERR, "Unable to parse serial number: %s\n",
-                serialNumbers[i]);
+                serialNumbers[i].c_str());
             break;
         }
         pDevices->push_back(device);

--- a/src/main.cc
+++ b/src/main.cc
@@ -131,7 +131,7 @@ void parseFile(void)
 gboolean updateStats(gpointer data)
 {
     LOG_EVENT(LOG_INFO, "Updating device stats for [%s]\n",
-        targetDevice.serialNumber);
+        targetDevice.serialNumber.c_str());
 
     int previousWriteSectors = targetDevice.stats.writeSectors;
 


### PR DESCRIPTION
Add missing `.c_str()` to the `LOG_EVENT` calls when printing a `std::string`. This was broken in multiple places and will close #40