### PR TITLE
cJsonParser: fix SIGSEGV in getValueAsInt

### DIFF
--- a/src/daemon/cJsonParser.cc
+++ b/src/daemon/cJsonParser.cc
@@ -220,7 +220,7 @@ bool cJsonParser::getValueAsInt(
     {
         LOG_EVENT(
             LOG_ERR, "Unable to parse '%s': %s\n", itemName.c_str(), pError->message);
-        g_error_free(pError);
+        json_reader_end_member(pReader);
         return false; // failure
     }
 


### PR DESCRIPTION
`g_error_free` was freeing the pReader which meant we were accessing invalid memory which caused the error message to also be at an invalid memory address, resulting in a SIGSEGV

Closes #22