### PR TITLE
main: correctly free pError on exit

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -241,7 +241,7 @@ void onExit(void)
     parser.closeJson();
     if (pError)
     {
-        g_object_unref(pError);
+        g_error_free(pError);
     }
     if (pContext)
     {


### PR DESCRIPTION
The correct free wasn't used which would cause a SIGSEGV if exiting with an error, e.g. failed to parse the command line parameters

Closes #72