### PR TITLE
main: add JSON config option and parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ A utility for monitoring and logging block device stats to a JSON file at a regu
 3. KrillKounter can be configured by editing `Enviroment` values within `/lib/systemd/system/KrillKounter.service`;
 
 ```
+KK_CONFIG_PATH - Path to the JSON file to be used for configuring the daemon in JSON instead of configuring via the variables below
+
 KK_STATS_PATH - Path to the JSON file to be used for logging of block device stats and info.
 
 KK_DEVICE_PATH - Path to the target block device to be monitored by KrillKounter [e.g. /dev/sda]

--- a/src/daemon/cJsonParser.hh
+++ b/src/daemon/cJsonParser.hh
@@ -12,6 +12,7 @@ class cJsonParser
     public:
         bool openJson(std::string jsonPath);
         bool closeJson();
+        bool getConfig(jsonDeviceConfig* pConfig);
         bool getTotalBytesWritten(std::string serialNumber, gint64* pValue);
         bool getDiskSeq(std::string serialNumber, gint64* pValue);
         bool getStats(std::string serialNumber, struct sBlockStats* pStats);
@@ -21,6 +22,8 @@ class cJsonParser
     private:
         bool getValueAsInt(
             JsonReader* pReader, std::string itemName, gint64 * pValue);
+        bool getValueAsString(
+            JsonReader* pReader, std::string itemName, std::string* pValue);
         JsonParser* _pJsonParser;
         int _parserOpen = false;
 };

--- a/src/daemon/service/KrillKounter.service
+++ b/src/daemon/service/KrillKounter.service
@@ -12,6 +12,7 @@ Environment=KK_DEVICE_NAME=sda
 Environment=KK_UPDATE_RATE=3600
 Environment=KK_SECTOR_SIZE=512
 ExecStart=/usr/bin/KrillKounter \
+-c ${KK_CONFIG_PATH} \
 -s ${KK_STATS_PATH} \
 -d ${KK_DEVICE_PATH} \
 -n ${KK_DEVICE_NAME} \

--- a/src/library/include/structs.hh
+++ b/src/library/include/structs.hh
@@ -62,4 +62,12 @@ struct jsonDeviceEntry
         gint64 diskSeq;
 };
 
+
+struct jsonDeviceConfig
+{
+        std::string deviceName;
+        std::string devicePath;
+        gint64 updateRate;
+        std::string statsFilePath;
+};
 #endif /* _STRUCTS_H */


### PR DESCRIPTION
Try to parse the config at either the supplied path, or default path. If not, fallback to the default values.

Passing a `std::string pointer` to the `GOptionEntry` was causing memory issues so I changed it to `gchar *`, not had any issues thus far.

Closes #66