### PR TITLE
main: add multi device monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A utility for monitoring and logging block device stats to a JSON file at a regu
 
 # Installation
 1. From inside the previously created `build/` subdirectory, run the command `sudo cmake --build . --target install`. This will install the executable to `/usr/bin/KrillKounter`, and the systemd service file to `/lib/systemd/system/KrillKounter.service`.
-3. KrillKounter can be configured by editing `Enviroment` values within `/lib/systemd/system/KrillKounter.service`;
+2. KrillKounter can be configured by editing `Enviroment` values within `/lib/systemd/system/KrillKounter.service`;
 
 ```
 KK_CONFIG_PATH - Path to the JSON file to be used for configuring the daemon in JSON instead of configuring via the variables below
@@ -31,7 +31,20 @@ KK_DEVICE_NAME - Name of the target block device to be monitored by KrillKounter
 KK_UPDATE_RATE - Time interval to wait between JSON file updates, in seconds.
 ```
 
-4. Enable and start the KrillKounter systemd service using the following command `systemctl enable --now KrillKounter.service`. The state of the KrillKounter service can be monitored using the command `systemctl status KrillKounter`.
+3. Enable and start the KrillKounter systemd service using the following command `systemctl enable --now KrillKounter.service`. The state of the KrillKounter service can be monitored using the command `systemctl status KrillKounter`.
+
+## Config File Format
+```JSON
+{
+    "devices": [
+        "/dev/sda",
+        "/dev/mmcblk0"
+    ],
+    "updateRate": 3600,
+    "statsFilePath": "/usr/share/KrillKounter/stats.json"
+}
+```
+devices is an array of device paths you wish to monitor
 
 # Contributing
 Issue a PR and follow the guidelines outlined in the CodingStyle.md

--- a/src/daemon/cJsonParser.hh
+++ b/src/daemon/cJsonParser.hh
@@ -12,7 +12,7 @@ class cJsonParser
     public:
         bool openJson(std::string jsonPath);
         bool closeJson();
-        bool getConfig(jsonDeviceConfig* pConfig);
+        bool getConfig(sJsonDevicesConfig* pConfig);
         bool getTotalBytesWritten(std::string serialNumber, gint64* pValue);
         bool getDiskSeq(std::string serialNumber, gint64* pValue);
         bool getStats(std::string serialNumber, struct sBlockStats* pStats);

--- a/src/daemon/cJsonWriter.cc
+++ b/src/daemon/cJsonWriter.cc
@@ -22,7 +22,7 @@ bool cJsonWriter::writeJson(std::string jsonPathInput,
     if (f.good())
     {
         // load existing data
-        std::vector<struct jsonDeviceEntry> devices;
+        std::vector<struct sJsonDeviceEntry> devices;
         if (!readExistingJson(jsonPathInput, &devices))
         {
             LOG_EVENT(LOG_ERR, "Unable to read existing json file: %s\n",
@@ -86,7 +86,7 @@ bool cJsonWriter::writeJson(std::string jsonPathInput,
 // private functions
 
 bool cJsonWriter::readExistingJson(
-    std::string jsonPath, std::vector<struct jsonDeviceEntry>* pDevices)
+    std::string jsonPath, std::vector<struct sJsonDeviceEntry>* pDevices)
 {
     // open file
     cJsonParser parser;
@@ -104,15 +104,16 @@ bool cJsonWriter::readExistingJson(
         return false; // failure
     }
 
-    // build jsonDeviceEntry for each device in json file, add to pDevices
+    // build sJsonDeviceEntry for each device in json file, add to pDevices
     for (uint i = 0; i < serialNumbers.size(); i++)
     {
-        struct jsonDeviceEntry device;
+        struct sJsonDeviceEntry device;
         bool error = false;
 
         device.serialNumber = serialNumbers[i];
         error |= !parser.getPath(device.serialNumber, &device.previousPath);
         error |= !parser.getStats(device.serialNumber, &device.stats);
+        error |= !parser.getDiskSeq(device.serialNumber, &device.diskSeq);
         error |= !parser.getTotalBytesWritten(
             device.serialNumber, &device.totalBytesWritten);
 

--- a/src/daemon/cJsonWriter.hh
+++ b/src/daemon/cJsonWriter.hh
@@ -20,7 +20,7 @@ class cJsonWriter
         uint _indentLevel = 4;
         JsonBuilder* _pJsonBuilder;
         bool readExistingJson(std::string jsonPath,
-            std::vector<struct jsonDeviceEntry>* pDevices);
+            std::vector<struct sJsonDeviceEntry>* pDevices);
         void addEntryToBuilder(std::string serialNumber,
             std::string previousPath, struct sBlockStats* pStats,
             gint64 diskSeq, gint64 totalBytesWritten);

--- a/src/library/include/structs.hh
+++ b/src/library/include/structs.hh
@@ -4,6 +4,7 @@
 
 #include <glib.h>
 #include <string>
+#include <vector>
 
 struct sBlockStatStub
 {
@@ -52,22 +53,30 @@ struct sDeviceSpecs
         struct sBlockStatStub mdt;
 };
 
-struct jsonDeviceEntry
+struct sDeviceEntry
 {
         std::string serialNumber;
-        std::string previousPath;
+        std::string deviceName;
+        std::string devicePath;
         struct sBlockStats stats;
         struct sBlockStats outputStats;
         gint64 totalBytesWritten;
         gint64 diskSeq;
 };
 
-
-struct jsonDeviceConfig
+struct sJsonDeviceEntry
 {
-        std::string deviceName;
-        std::string devicePath;
-        gint64 updateRate;
+        std::string serialNumber;
+        std::string previousPath;
+        struct sBlockStats stats;
+        gint64 totalBytesWritten;
+        gint64 diskSeq;
+};
+
+struct sJsonDevicesConfig
+{
+        std::vector<std::string> devices;
         std::string statsFilePath;
+        gint64 updateRate;
 };
 #endif /* _STRUCTS_H */


### PR DESCRIPTION
This uses the newly added JSON config parser (#77) to declare the devices to monitor. Currently we have an array of device paths, and a single stats file output, and single update rate.

The config file is in the format

```JSON
{
    "devices": [
        "/dev/sda",
        "/dev/mmcblk0"
    ],
    "updateRate": 3600,
    "statsFilePath": "/usr/share/KrillKounter/stats.json"
}
```

Modified the necessary functions to iterate over all devices in the array instead of working on a single global variable.

Closes #46