### PR TITLE
Added array parsing fallback for version < 1.8.0

### DIFF
--- a/src/daemon/cJsonParser.hh
+++ b/src/daemon/cJsonParser.hh
@@ -24,6 +24,7 @@ class cJsonParser
             JsonReader* pReader, std::string itemName, gint64 * pValue);
         bool getValueAsString(
             JsonReader* pReader, std::string itemName, std::string* pValue);
+        bool getDevicesArray(JsonReader* pReader, sJsonDevicesConfig* pConfig);
         JsonParser* _pJsonParser;
         int _parserOpen = false;
 };


### PR DESCRIPTION
For json-glib versions <1.8.0 (e.g. on kirkstone) the `json_reader_get_current_node` function does not exist, and as such we are not able to use the array functions with the node pointer. We check the library version to decide which method to use; should the old interface be deprecated or the flexibility of the newer interface be desired for new features, it will be helpful to have both versions.

Closes #85