### PR TITLE
Add shared library target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,13 +23,29 @@ file(GLOB sources CONFIGURE_DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/src/*/*.cc
 )
 
-add_executable(KrillKounter src/main.cc ${sources})
+# Shared Library
+add_library(krillkounter SHARED ${sources})
+
+target_include_directories(krillkounter PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
+
+# Link libraries
+target_link_libraries(krillkounter PUBLIC ${JSONGLIB_LIBRARIES})
+target_link_libraries(krillkounter PUBLIC ${CMAKE_DL_LIBS})
+
+set_target_properties(krillkounter PROPERTIES
+        LINKER_LANGUAGE CXX
+        VERSION ${CMAKE_PROJECT_VERSION}
+        SOVERSION ${PROJECT_VERSION_MAJOR}
+)
+
+
+add_executable(KrillKounter src/main.cc)
 
 # Include directories
 include_directories(${JSONGLIB_INCLUDE_DIRS})
 
 target_include_directories(KrillKounter PUBLIC
-    ${CMAKE_CURRENT_SOURCE_DIR}/src
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 
 # Link libraries
@@ -37,8 +53,11 @@ target_link_libraries(KrillKounter PUBLIC ${JSONGLIB_LIBRARIES})
 
 target_link_libraries(KrillKounter PUBLIC ${CMAKE_DL_LIBS})
 
+target_link_libraries(KrillKounter PUBLIC krillkounter)
+
 # We link C++ files
 set_target_properties(KrillKounter PROPERTIES LINKER_LANGUAGE CXX)
+
 
 # Project metadata
 set(CPACK_PROJECT_NAME ${PROJECT_NAME})
@@ -47,4 +66,11 @@ include(CPack)
 
 install(DIRECTORY DESTINATION  /usr/share/KrillKounter)
 install(TARGETS KrillKounter RUNTIME DESTINATION /usr/bin)
+
+install(TARGETS krillkounter LIBRARY DESTINATION /usr/lib)
+install(DIRECTORY ${CMAKE_SOURCE_DIR}/src/library/
+        DESTINATION /usr/include/KrillKounter
+        FILES_MATCHING PATTERN "*.hh"
+)
+
 install(FILES src/daemon/service/KrillKounter.service DESTINATION /lib/systemd/system)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(KrillKounter VERSION 0.1.0)
+project(KrillKounter VERSION 0.0.2)
 
 # C++20
 set(CMAKE_CXX_STANDARD 20)


### PR DESCRIPTION
Added the library folder as a shared library target with version properties as required by oe_install. Added install step for the library header files to be placed at /usr/include/KrillKounter.

Closes #87