### PR TITLE
Remove unsupported -b option from .service file

### DIFF
--- a/src/daemon/service/KrillKounter.service
+++ b/src/daemon/service/KrillKounter.service
@@ -16,8 +16,7 @@ ExecStart=/usr/bin/KrillKounter \
 -s ${KK_STATS_PATH} \
 -d ${KK_DEVICE_PATH} \
 -n ${KK_DEVICE_NAME} \
--r ${KK_UPDATE_RATE} \
--b ${KK_SECTOR_SIZE}
+-r ${KK_UPDATE_RATE}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
When using the example SystemD service file, the following error occurs:

Apr 16 18:57:27 little-machine systemd[1]: Started Start KrillKounter daemon.
Apr 16 18:57:27 little-machine KrillKounter[49110]: [main:334]: Starting app.
Apr 16 18:57:27 little-machine KrillKounter[49110]: [main:347]: option parsing failed: Unknown option -b
Apr 16 18:57:27 little-machine KrillKounter[49110]: [closeJson:36]: No JSON open

This is because the -b option no longer exists, lets fix this by removing its use from the service file.