### PR TITLE
cmake: Add -Wall to g++ options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(KrillKounter VERSION 0.3.0)
 
 # C++20
 set(CMAKE_CXX_STANDARD 20)
-set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wshadow=local")
+set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wall -Wshadow=local")
 
 # Find packages and libraries
 find_package(PkgConfig REQUIRED)

--- a/src/main.cc
+++ b/src/main.cc
@@ -99,12 +99,12 @@ void getSerialNumber(std::string devicePath)
 static std::string getCurrentTimestamp(void)
 {
     const auto currentTime = std::chrono::system_clock::now();
-    auto in_time_t = std::chrono::system_clock::to_time_t(currentTime);
 
-    std::stringstream ss;
 #ifdef __cpp_lib_format
     return std::format("{:%d-%m-%Y %H:%M:%OS}", currentTime);
 #else
+    auto in_time_t = std::chrono::system_clock::to_time_t(currentTime);
+    std::stringstream ss;
     ss << std::put_time(std::localtime(&in_time_t), "%d-%m-Y %H:%M:%OS");
     return ss.str();
 #endif


### PR DESCRIPTION
Turn on all warnings to catch as many mistakes as possible. Fix the unused variables that crept in in a recent commit.
Fixes #101 